### PR TITLE
fixed migration counter name bug, and created working get/post api counter route

### DIFF
--- a/packages/backend/db/migrations/20210412215125_create_counter.ts
+++ b/packages/backend/db/migrations/20210412215125_create_counter.ts
@@ -2,7 +2,7 @@ import { Knex } from "knex";
 
 
 export async function up(knex: Knex): Promise<void> {
-  return knex.schema.createTable('counter', t => {
+  return knex.schema.createTable('counters', t => {
     t.increments('id').primary().unsigned()
     t.integer('counter').defaultTo(0).notNullable()
   })

--- a/packages/backend/db/seeds/002_counter.ts
+++ b/packages/backend/db/seeds/002_counter.ts
@@ -2,10 +2,10 @@ import { Knex } from "knex";
 
 export async function seed(knex: Knex): Promise<void> {
     // Deletes ALL existing entries
-    await knex("counter").del();
+    await knex("counters").del();
 
     // Inserts seed entries
-    await knex("counter").insert([
+    await knex("counters").insert([
         { id: 1, counter: 1 },
         { id: 2, counter: 2 },
         { id: 3, counter: 3 },

--- a/packages/backend/server/models/counter.ts
+++ b/packages/backend/server/models/counter.ts
@@ -8,7 +8,6 @@ const selectableProps = ['id', 'counter'];
 
 const createGuts = require('../helpers/model-guts');
 
-
 module.exports = (knex) => {
   const guts = createGuts({
     knex,

--- a/packages/backend/server/routes/counter.ts
+++ b/packages/backend/server/routes/counter.ts
@@ -4,9 +4,24 @@ const {Counter} = require('../models');
 
 router.get('/', async (req, res, next) => {
     try {
-        const currentCounter = await Counter.findById(1);
-        res.send(currentCounter);
+        const {counter} = await Counter.findById(1);
+        res.send(counter);
     } catch (error) {
-        next();         
+        next(error);         
     }        
 })
+
+router.post('/', async (req, res, next) => {
+    try {
+        const data = await Counter.findById(1);
+        const counter = await data[0].counter;
+        if(req.body.change === 'INCREMENT') await Counter.update(1, {counter: counter + 1})
+        if (req.body.change === 'DECREMENT') await Counter.update(1, {counter: counter - 1})
+
+        res.send("UPDATE SUCCESS");
+    } catch (error) {
+        next(error);         
+    }        
+})
+
+module.exports = router; 


### PR DESCRIPTION
counter table is now called counters (changed migration file)
Get route for localhost:5000/counter, spits back db value for counter with id of 1
Post route with a change value of INCREMENT will increase counter id 1 by 1
Post route with a change value of DECREMENT will decreasese counter id 1 by 1